### PR TITLE
Replace remaining cecho calls with ANSI escape codes

### DIFF
--- a/mbr_bootloader/BUILD.BAT
+++ b/mbr_bootloader/BUILD.BAT
@@ -2,13 +2,13 @@
 cd %~d0%~p0
 call CLEAN.BAT
 
-cecho {09}Assembling{0F}{\t}==^> boot_mbr.asm...{#}
+echo|set /p dummy="[94mAssembling[97m	==> boot_mbr.asm...[0m"
 nasm -f bin boot_mbr.asm -o boot_mbr.bin || goto ERROR
-cecho {0a}done{#}{\n}
+echo [92mdone[0m
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/stage1_bootloader/BUILD.BAT
+++ b/stage1_bootloader/BUILD.BAT
@@ -2,16 +2,16 @@
 cd %~d0%~p0
 call CLEAN.BAT
 
-if not exist ..\stage2_bootloader\boot2.map cecho {0C}You have to build the second stage bootloader first{#}{\n}&&goto ERROR
+if not exist ..\stage2_bootloader\boot2.map echo [91mYou have to build the second stage bootloader first[0m&&goto ERROR
 for /f "tokens=1" %%i in ('findstr /R /C:"[0-9a-fA-F][0-9a-fA-F]*  *OperatingSystemName" ..\stage2_bootloader\boot2.map') do set BPB_OFFSET=0x%%i
 
-cecho {09}Assembling{0F}{\t}==^> boot.asm...{#}
+echo|set /p dummy="[94mAssembling[97m	==> boot.asm...[0m"
 nasm -f bin -D BPB_OFFSET=%BPB_OFFSET% boot.asm -o boot.bin || goto ERROR
-cecho {0a}done{#}{\n}
+echo [92mdone[0m
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/stage2_bootloader/BUILD.BAT
+++ b/stage2_bootloader/BUILD.BAT
@@ -2,13 +2,13 @@
 cd %~d0%~p0
 call CLEAN.BAT
 
-cecho {09}Assembling{0F}{\t}==^> boot2.asm...{#}
+echo|set /p dummy="[94mAssembling[97m	==> boot2.asm...[0m"
 nasm -f bin boot2.asm -o BOOT2.SYS || goto ERROR
-cecho {0a}done{#}{\n}
+echo [92mdone[0m
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_programs/cpptest/BUILD.bat
+++ b/user/user_programs/cpptest/BUILD.bat
@@ -5,7 +5,7 @@ make --makefile=makefile SHELL=cmd || goto ERROR
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_programs/pcilist/BUILD.bat
+++ b/user/user_programs/pcilist/BUILD.bat
@@ -5,7 +5,7 @@ make --makefile=makefile SHELL=cmd || goto ERROR
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_programs/raycaster/BUILD.bat
+++ b/user/user_programs/raycaster/BUILD.bat
@@ -5,7 +5,7 @@ make --makefile=makefile SHELL=cmd || goto ERROR
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_programs/shell/BUILD.bat
+++ b/user/user_programs/shell/BUILD.bat
@@ -5,7 +5,7 @@ make --makefile=makefile SHELL=cmd || goto ERROR
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_programs/threadtest/BUILD.bat
+++ b/user/user_programs/threadtest/BUILD.bat
@@ -5,7 +5,7 @@ make --makefile=makefile SHELL=cmd || goto ERROR
 goto EOF
 
 :ERROR
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF

--- a/user/user_tools/BUILD.BAT
+++ b/user/user_tools/BUILD.BAT
@@ -6,13 +6,13 @@ mkdir obj >nul 2>&1
 
 cd src
 
-cecho {09}Assembling{0F}{\t}==^> start.asm...{#}
+echo|set /p dummy="[94mAssembling[97m	==> start.asm...[0m"
 nasm -O32 -f elf start.asm -o ../obj/start.o || goto ERROR
-cecho {0a}done{#}{\n}
+echo [92mdone[0m
 
-cecho {09}Compiling{0F}{\t}==^> userlib.c...{#}
+echo|set /p dummy="[94mCompiling[97m	==> userlib.c...[0m"
 i686-elf-gcc -std=c99 -c -Werror -Wall -O -ffreestanding -fleading-underscore -nostdlib -nostdinc -fno-builtin -ffunction-sections -fdata-sections -Iinclude userlib.c -o ../obj/userlib.o || goto ERROR
-cecho {0a}done{#}{\n}
+echo [92mdone[0m
 
 cd %~d0%~p0
 
@@ -30,7 +30,7 @@ goto EOF
 
 :ERROR
 cd %~d0%~p0
-cecho {0C}Error{#}{\n}
+echo [91mError[0m
 EXIT /B 1
 
 :EOF


### PR DESCRIPTION
Replace remaining occurrences of cecho with ANSI escape sequences in
Windows build scripts.